### PR TITLE
fix(reporting):custom field renaming - backslashes in config handled 

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -92,6 +92,7 @@ namespace iSAMS.Utilities.Reporting.CustomFieldRenaming
                 using (StreamReader reader = new StreamReader(path))
                 {
                     string json = reader.ReadToEnd();
+                    json = json.Replace(@"\", @"\\\\");
                     Config = JsonConvert.DeserializeObject<ScriptConfiguration>(json);
                     Console.WriteLine("Utility settings parsed successfully.");
                 }


### PR DESCRIPTION
Backslashes found in the JSON config file are modified before deserializing.

Previously the application would fail to parse the JSON as the backslashes were being treated as special characters.